### PR TITLE
:sparkles: feat(model deletion): DataMiningModels can be deleted on t…

### DIFF
--- a/ppddm-manager/src/main/scala/ppddm/manager/controller/dm/DataMiningModelController.scala
+++ b/ppddm-manager/src/main/scala/ppddm/manager/controller/dm/DataMiningModelController.scala
@@ -254,19 +254,13 @@ object DataMiningModelController {
    * @return The deleted Dataset object if operation is successful, None otherwise.
    */
   def deleteDataMiningModel(model_id: String): Future[Option[DataMiningModel]] = {
-    db.getCollection[DataMiningModel](COLLECTION_NAME).findOneAndDelete(equal("model_id", model_id)).headOption()
-    //    flatMap { dataMiningModelOption: Option[DataMiningModel] =>
-    //      if (dataMiningModelOption.isDefined) {
-    //        val dataMiningModel = dataMiningModelOption.get
-    //        Future.sequence(
-    //          dataMiningModel.data_mining_sources.get.map { dataMiningSource: DataMiningSource => // For each DataMiningSource in this set
-    //            DistributedDataMiningManager.deleteAlgorithmExecutionResult(dataMiningSource.agent, dataMiningModel) // Delete the algorithm execution results from the Agents (do this in parallel)
-    //          }) map { _ => Some(dataMiningModel) }
-    //      }
-    //      else {
-    //        Future.apply(Option.empty[DataMiningModel])
-    //      }
-    //    }
+    db.getCollection[DataMiningModel](COLLECTION_NAME).findOneAndDelete(equal("model_id", model_id))
+      .headOption()
+      .recover {
+        case e: Exception =>
+          val msg = s"Error while deleting the DataMiningModel with model_id:${model_id}."
+          throw DBException(msg, e)
+      }
   }
 
 }


### PR DESCRIPTION
…he AGents when they are deleted on the Platform, according to the new ppddm architecture. Closes #135

## Proposed Changes
  - Data mining model can be deleted on the Platform and from the Agents.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Tests
- [X] Build locally
- [X] Code format / lint
- [X] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #135 
