### PR TITLE
:sparkles: feat(ppddm-manager): When a Project(use-case) is deleted, …

### DIFF
--- a/ppddm-core/src/main/scala/ppddm/core/rest/model/RestModel.scala
+++ b/ppddm-core/src/main/scala/ppddm/core/rest/model/RestModel.scala
@@ -39,6 +39,10 @@ final case class Featureset(featureset_id: Option[String],
   def withUniqueFeaturesetId: Featureset = {
     this.copy(featureset_id = Some(UUID.randomUUID().toString), created_on = Some(LocalDateTime.now()))
   }
+
+  def withNewProjectId(newProjectId: String): Featureset = {
+    this.copy(project_id = newProjectId)
+  }
 }
 
 final case class Variable(name: String,
@@ -61,6 +65,10 @@ final case class Dataset(dataset_id: Option[String],
 
   def withUniqueDatasetId: Dataset = {
     this.copy(dataset_id = Some(UUID.randomUUID().toString), created_on = Some(LocalDateTime.now()))
+  }
+
+  def withNewProjectId(newProjectId: String): Dataset = {
+    this.copy(project_id = newProjectId)
   }
 
   def withDatasetSources(dataset_sources: Seq[DatasetSource]): Dataset = {
@@ -213,6 +221,10 @@ final case class DataMiningModel(model_id: Option[String],
 
   def withUniqueModelId: DataMiningModel = {
     this.copy(model_id = Some(UUID.randomUUID().toString), created_on = Some(LocalDateTime.now()))
+  }
+
+  def withNewProjectId(newProjectId: String): DataMiningModel = {
+    this.copy(project_id = newProjectId)
   }
 
   def withDataMiningState(dataMiningState: DataMiningState): DataMiningModel = {
@@ -448,6 +460,7 @@ final case class ModelTestResult(model_id: String,
                                  test_statistics: Seq[AgentAlgorithmStatistics]) extends ModelClass
 
 final case class ProspectiveStudy(prospective_study_id: Option[String],
+                                  project_id: String,
                                   name: String,
                                   description: String,
                                   data_mining_model: DataMiningModel,
@@ -456,6 +469,10 @@ final case class ProspectiveStudy(prospective_study_id: Option[String],
                                   created_on: Option[LocalDateTime]) extends ModelClass {
   def withUniqueProspectiveStudyId: ProspectiveStudy = {
     this.copy(prospective_study_id = Some(UUID.randomUUID().toString), created_on = Some(LocalDateTime.now()))
+  }
+
+  def withNewProjectId(newProjectId: String): ProspectiveStudy = {
+    this.copy(project_id = newProjectId)
   }
 }
 

--- a/ppddm-manager/src/main/scala/ppddm/manager/controller/project/ProjectController.scala
+++ b/ppddm-manager/src/main/scala/ppddm/manager/controller/project/ProjectController.scala
@@ -1,14 +1,21 @@
 package ppddm.manager.controller.project
 
+import akka.Done
 import com.typesafe.scalalogging.Logger
 import org.mongodb.scala.model.Filters.equal
 import org.mongodb.scala.model.{FindOneAndReplaceOptions, ReturnDocument}
 import ppddm.core.exception.DBException
 import ppddm.core.rest.model.Project
 import ppddm.manager.Manager
+import ppddm.manager.controller.dataset.DatasetController
+import ppddm.manager.controller.dm.DataMiningModelController
+import ppddm.manager.controller.featureset.FeaturesetController
+import ppddm.manager.controller.prospective.ProspectiveStudyController
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future, TimeoutException}
+import scala.concurrent.duration.Duration
 
 /**
  * Controller object for the Projects. Each use-case of FAIR4Health can be modeled as a Project.
@@ -27,7 +34,7 @@ object ProjectController {
    * @return The created Project object with a unique project_id in it
    */
   def createProject(project: Project): Future[Project] = {
-    if(project.project_id.isDefined) {
+    if (project.project_id.isDefined) {
       throw new IllegalArgumentException("If you want to create a new project, please provide it WITHOUT a project_id")
     }
     val projectWithId = project.withUniqueProjectId // Create a new, timestamped, Project object with a unique identifier
@@ -97,17 +104,60 @@ object ProjectController {
   /**
    * Deletes Project from the Platform Repository.
    *
-   * @param project_id The unique identifier of the Project to be deleted.
+   * @param project_id              The unique identifier of the Project to be deleted.
+   * @param withAssociatedResources if true, delete all associated resources (Featureset, Dataset, DataMiningModel, ProspectiveStudy) of this project
+   *                                from the platform database and their associated resources on the distributed agents
    * @return The deleted Project object if operation is successful, None otherwise.
    */
-  def deleteProject(project_id: String): Future[Option[Project]] = {
-    db.getCollection[Project](COLLECTION_NAME).findOneAndDelete(equal("project_id", project_id))
-      .headOption()
-      .recover {
-        case e: Exception =>
-          val msg = s"Error while deleting the Project with project_id:${project_id} from the database."
-          throw DBException(msg, e)
+  def deleteProject(project_id: String, withAssociatedResources: Boolean = false, isTest: Boolean = false): Future[Option[Project]] = {
+    val f = if (withAssociatedResources) {
+      FeaturesetController.getAllFeaturesets(project_id) flatMap { featuresets => // Find all featuresets under this project
+        FeaturesetController.deleteManyFeaturesets(featuresets.map(_.featureset_id.get)) flatMap { deletedFeaturesetCount => // Delete all Featuresets with a single function call
+          deletedFeaturesetCount
+          DatasetController.getAllDatasets(project_id, isTest) flatMap { datasets => // Find all datasets under this project
+            datasets foreach { dataset => //Delete them one by one
+              try { // Wait for dataset deletion to be completed because it includes Agent communication
+                Await.result(DatasetController.deleteDataset(dataset.dataset_id.get, isTest), Duration(60, TimeUnit.SECONDS))
+              } catch {
+                case e: TimeoutException =>
+                  val msg = s"Dataset deletion cannot be completed within 60 seconds. Dataset: ${dataset.dataset_id.get} Project: ${project_id}"
+                  logger.error(msg, e)
+                  throw DBException(msg, e)
+              }
+            }
+            DataMiningModelController.getAllDataMiningModels(project_id) flatMap { dataMiningModels => // Find all DataMiningModels under this project
+              dataMiningModels foreach { dataMiningModel =>
+                try { // Wait for data mining model deletion to be completed because it includes Agent communication
+                  Await.result(DataMiningModelController.deleteDataMiningModel(dataMiningModel.model_id.get, isTest), Duration(60, TimeUnit.SECONDS))
+                  Await.result(DataMiningModelController.deleteDataMiningModel(dataMiningModel.model_id.get, isTest), Duration(60, TimeUnit.SECONDS))
+                } catch {
+                  case e: TimeoutException =>
+                    val msg = s"DataMiningModel deletion cannot be completed within 60 seconds. DataMiningModel: ${dataMiningModel.model_id.get} Project: ${project_id}"
+                    logger.error(msg, e)
+                    throw DBException(msg, e)
+                }
+              }
+              ProspectiveStudyController.getAllProspectiveStudies(project_id) flatMap { prospectiveStudies => // Find all ProspectiveStudies under this project
+                // Delete all ProspectiveStudies with a single function call
+                ProspectiveStudyController.deleteManyProspectiveStudies(prospectiveStudies.map(_.prospective_study_id.get)) map { _ => Done }
+              }
+            }
+          }
+        }
       }
+    } else {
+      Future.apply(Done)
+    }
+
+    f flatMap { _ =>
+      db.getCollection[Project](COLLECTION_NAME).findOneAndDelete(equal("project_id", project_id))
+        .headOption()
+        .recover {
+          case e: Exception =>
+            val msg = s"Error while deleting the Project with project_id:${project_id} from the database."
+            throw DBException(msg, e)
+        }
+    }
   }
 
 }

--- a/ppddm-manager/src/main/scala/ppddm/manager/gateway/api/endpoint/DataMiningModelEndpoint.scala
+++ b/ppddm-manager/src/main/scala/ppddm/manager/gateway/api/endpoint/DataMiningModelEndpoint.scala
@@ -22,7 +22,7 @@ trait DataMiningModelEndpoint {
               complete { // Create a new DataMiningModel and return the created entity
                 DataMiningModelController.createDataMiningModel(datamining_model) map { dataMiningModel =>
 
-                  if(test.isEmpty) { // Start the orchestration only if this call is NOT for testing purposes
+                  if (test.isEmpty) { // Start the orchestration only if this call is NOT for testing purposes
                     // After the DataMiningModel is saved into the database, start an orchestration process for this model
                     // so that model training, validation and testing are executed through the distributed data mining approach
                     // Do not wait this orchestration to be completed, start the orchestration and return.
@@ -61,14 +61,7 @@ trait DataMiningModelEndpoint {
             delete {
               parameters("_test".?) { test =>
                 complete { // Delete the DataMiningModel
-                  DataMiningModelController.deleteDataMiningModel(model_id) flatMap { dataMiningModel =>
-                    if(dataMiningModel.isDefined && test.isEmpty) {
-                      // Delete the data for this DataMiningModel on Agents
-                      DistributedDataMiningManager.deleteDataMiningModelFromAgents(dataMiningModel.get)
-                    } else {
-                      Future { Done }
-                    }
-                  }
+                  DataMiningModelController.deleteDataMiningModel(model_id, test.isDefined)
                 }
               }
             }

--- a/ppddm-manager/src/main/scala/ppddm/manager/gateway/api/endpoint/ProjectEndpoint.scala
+++ b/ppddm-manager/src/main/scala/ppddm/manager/gateway/api/endpoint/ProjectEndpoint.scala
@@ -23,34 +23,36 @@ trait ProjectEndpoint {
             }
           }
         } ~
-        get {
-          complete {
-            ProjectController.getAllProjects
-          }
-        }
-      }
-    } ~
-    pathPrefix("project" / Segment) { project_id =>
-      pathEndOrSingleSlash {
-        get {
-          complete {
-            ProjectController.getProject(project_id)
-          }
-        } ~
-        put {
-          entity(as[Project]) { project =>
+          get {
             complete {
-              ProjectController.updateProject(project)
+              ProjectController.getAllProjects
             }
           }
-        } ~
-        delete {
-          complete {
-            ProjectController.deleteProject(project_id)
-          }
+      }
+    } ~
+      pathPrefix("project" / Segment) { project_id =>
+        pathEndOrSingleSlash {
+          get {
+            complete {
+              ProjectController.getProject(project_id)
+            }
+          } ~
+            put {
+              entity(as[Project]) { project =>
+                complete {
+                  ProjectController.updateProject(project)
+                }
+              }
+            } ~
+            delete {
+              parameters("_all".?, "_test".?) { (all, test) =>
+                complete {
+                  ProjectController.deleteProject(project_id, withAssociatedResources = all.isDefined, isTest = test.isDefined)
+                }
+              }
+            }
         }
       }
-    }
   }
 
 }

--- a/ppddm-manager/src/main/scala/ppddm/manager/gateway/api/endpoint/ProspectiveStudyEndpoint.scala
+++ b/ppddm-manager/src/main/scala/ppddm/manager/gateway/api/endpoint/ProspectiveStudyEndpoint.scala
@@ -23,9 +23,11 @@ trait ProspectiveStudyEndpoint {
             }
           }
         } ~
-          get {
-            complete {
-              ProspectiveStudyController.getAllProspectiveStudies
+          get { // get all ProspectiveStudies of project
+            parameters('project_id) { project_id =>
+              complete {
+                ProspectiveStudyController.getAllProspectiveStudies(project_id)
+              }
             }
           }
       }

--- a/ppddm-manager/src/test/resources/prospective-study.json
+++ b/ppddm-manager/src/test/resources/prospective-study.json
@@ -1,4 +1,5 @@
 {
+  "project_id": "868d40af-e840-47a6-bfec-5b1852a8d5af",
   "name": "Prospective study",
   "description": "Desc for prospective study",
   "data_mining_model": {

--- a/ppddm-manager/src/test/scala/ppddm/manager/api/endpoint/ProjectEndpointTest.scala
+++ b/ppddm-manager/src/test/scala/ppddm/manager/api/endpoint/ProjectEndpointTest.scala
@@ -4,10 +4,9 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.Authorization
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
-import ppddm.core.rest.model.Project
+import ppddm.core.rest.model.{DataMiningModel, Dataset, Featureset, Project, ProspectiveStudy}
 import ppddm.manager.PPDDMManagerEndpointTest
 import ppddm.manager.config.ManagerConfig
-
 import ppddm.core.rest.model.Json4sSupport._
 
 import scala.io.Source
@@ -20,8 +19,24 @@ class ProjectEndpointTest extends PPDDMManagerEndpointTest {
   lazy val projectRequest: Project =
     Source.fromResource("project.json").mkString
       .extract[Project]
+  lazy val featureset: Featureset =
+    Source.fromResource("featureset.json").mkString
+      .extract[Featureset]
+  lazy val bareDataset: Dataset =
+    Source.fromResource("dataset.json").mkString
+      .extract[Dataset]
+  lazy val bareDataMiningModel: DataMiningModel =
+    Source.fromResource("dataminingmodel.json").mkString
+      .extract[DataMiningModel]
+  lazy val prospectiveStudy: ProspectiveStudy =
+    Source.fromResource("prospective-study.json").mkString
+      .extract[ProspectiveStudy]
 
   var createdProject: Project = _
+  var createdFeatureset: Featureset = _
+  var createdDataset: Dataset = _
+  var createdDataMiningModel: DataMiningModel = _
+  var createdProspectiveStudy: ProspectiveStudy = _
 
   sequential
 
@@ -63,9 +78,48 @@ class ProjectEndpointTest extends PPDDMManagerEndpointTest {
       }
     }
 
-    "delete the project" in {
-      Delete("/" + ManagerConfig.baseUri + "/project/" + createdProject.project_id.get) ~> Authorization(bearerToken) ~> routes ~> check {
+    "create featureset, dataset, dataminingmodel and prospectivestudy under the project" in {
+      Post("/" + ManagerConfig.baseUri + "/featureset", featureset.withNewProjectId(createdProject.project_id.get)) ~> Authorization(bearerToken) ~> routes ~> check {
+        status shouldEqual Created
+        createdFeatureset = responseAs[Featureset]
+        createdFeatureset.name === featureset.name
+        createdFeatureset.project_id === createdProject.project_id.get
+      }
+      Post("/" + ManagerConfig.baseUri + "/dataset?_test", bareDataset.withNewProjectId(createdProject.project_id.get)) ~> Authorization(bearerToken) ~> routes ~> check {
+        status shouldEqual Created
+        createdDataset = responseAs[Dataset]
+        createdDataset.name === bareDataset.name
+        createdDataset.project_id === createdProject.project_id.get
+      }
+      Post("/" + ManagerConfig.baseUri + "/dm-model?_test", bareDataMiningModel.withNewProjectId(createdProject.project_id.get)) ~> Authorization(bearerToken) ~> routes ~> check {
+        status shouldEqual Created
+        createdDataMiningModel = responseAs[DataMiningModel]
+        createdDataMiningModel.name === bareDataMiningModel.name
+        createdDataMiningModel.project_id === createdProject.project_id.get
+      }
+      Post("/" + ManagerConfig.baseUri + "/prospective", prospectiveStudy.withNewProjectId(createdProject.project_id.get)) ~> Authorization(bearerToken) ~> routes ~> check {
+        status shouldEqual Created
+        createdProspectiveStudy = responseAs[ProspectiveStudy]
+        createdProspectiveStudy.name === prospectiveStudy.name
+        createdProspectiveStudy.project_id === createdProject.project_id.get
+      }
+    }
+
+    "delete the project with all associated resources" in {
+      Delete("/" + ManagerConfig.baseUri + "/project/" + createdProject.project_id.get + "?_all&_test") ~> Authorization(bearerToken) ~> routes ~> check {
         status shouldEqual OK
+      }
+      Get("/" + ManagerConfig.baseUri + "/featureset/" + createdFeatureset.featureset_id.get) ~> Authorization(bearerToken) ~> routes ~> check {
+        status shouldEqual NotFound
+      }
+      Get("/" + ManagerConfig.baseUri + "/dataset/" + createdDataset.dataset_id.get + "?_test") ~> Authorization(bearerToken) ~> routes ~> check {
+        status shouldEqual NotFound
+      }
+      Get("/" + ManagerConfig.baseUri + "/dm-model/" + createdDataMiningModel.model_id.get) ~> Authorization(bearerToken) ~> routes ~> check {
+        status shouldEqual NotFound
+      }
+      Get("/" + ManagerConfig.baseUri + "/prospective/" + createdProspectiveStudy.prospective_study_id.get) ~> Authorization(bearerToken) ~> routes ~> check {
+        status shouldEqual NotFound
       }
     }
   }

--- a/ppddm-manager/src/test/scala/ppddm/manager/api/endpoint/ProspectiveStudyEndpointTest.scala
+++ b/ppddm-manager/src/test/scala/ppddm/manager/api/endpoint/ProspectiveStudyEndpointTest.scala
@@ -88,7 +88,7 @@ class ProspectiveStudyEndpointTest extends PPDDMManagerEndpointTest {
         val response: ProspectiveStudy = responseAs[ProspectiveStudy]
         newProspectiveStudyID = response.prospective_study_id.get
       }
-      Get("/" + ManagerConfig.baseUri + "/prospective") ~> Authorization(bearerToken) ~> routes ~> check {
+      Get("/" + ManagerConfig.baseUri + "/prospective?project_id=" + prospectiveStudy.project_id) ~> Authorization(bearerToken) ~> routes ~> check {
         status shouldEqual OK
 
         val response: Seq[ProspectiveStudy] = responseAs[Seq[ProspectiveStudy]]


### PR DESCRIPTION
…all its associated resources can now be deleted if the _now query parameter is available in the request

## Proposed Changes
  - All Project resources (featuresets, datasets, dataminingmodels, prospectivestudies) are deleted once a Project is deleted with the _all parameter.
  - Tests have been improved to reflect the _all delete

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Tests
- [X] Build locally
- [X] Code format / lint
- [X] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #145 